### PR TITLE
Update HAMLIB_KEYER to fix speed controls and show more errors

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ tlf_SOURCES = \
 	genqtclist.c \
 	get_time.c getctydata.c getexchange.c getmessages.c getpx.c \
 	gettxinfo.c getwwv.c grabspot.c \
+	hamlib_keyer.c \
 	initial_exchange.c \
 	keyer.c \
 	lancode.c last10.c listmessages.c log_to_disk.c log_utils.c \
@@ -52,6 +53,7 @@ noinst_HEADERS = \
 	genqtclist.h \
 	get_time.h  getctydata.h getexchange.h getmessages.h getpx.h \
 	gettxinfo.h getwwv.h globalvars.h grabspot.h \
+	hamlib_keyer.h \
 	ignore_unused.h initial_exchange.h \
 	keyer.h keystroke_names.h \
 	lancode.h last10.h listmessages.h log_utils.h \

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -28,6 +28,7 @@
 #include <pthread.h>
 
 #include "bands.h"
+#include "cw_utils.h"
 #include "err_utils.h"
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
@@ -186,6 +187,23 @@ void gettxinfo(void) {
 	if (bandinx != oldbandinx) {	// band change on trx
 	    oldbandinx = bandinx;
 	    handle_trx_bandswitch((int) freq);
+	}
+
+	/* read speed from rig */
+	if (cwkeyer == HAMLIB_KEYER) {
+	    value_t rig_cwspeed;
+	    retval = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &rig_cwspeed); /* initialize RIG_VFO_CURR */
+
+	    if (retval == RIG_OK) {
+		if (GetCWSpeed() != rig_cwspeed.i) { // FIXME: doesn't work if rig speed is between the values from CW_SPEEDS
+		    SetCWSpeed(rig_cwspeed.i);
+
+		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+		    mvprintw(0, 14, "%2u", GetCWSpeed());
+		}
+	    } else {
+		TLF_LOG_WARN("Problem with rig link!");
+	    }
 	}
 
     } else if (reqf == SETCWMODE) {

--- a/src/hamlib_keyer.c
+++ b/src/hamlib_keyer.c
@@ -1,6 +1,6 @@
 /*
  * Tlf - contest logging program for amateur radio operators
- * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
+ * Copyright (C) 2001-2002-2003-2004-2005 Rein Couperus <pa0r@amsat.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,44 +16,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
-/* ------------------------------------------------------------
-*      Stop TX
-*
-*--------------------------------------------------------------*/
 
+#include <hamlib/rig.h>
 
-#include "clear_display.h"
-#include "err_utils.h"
 #include "globalvars.h"
 #include "hamlib_keyer.h"
-#include "netkeyer.h"
-#include "tlf.h"
-#include "tlf_curses.h"
 
-#include "fldigixmlrpc.h"
-
-int stoptx(void) {
-
-    if (digikeyer == FLDIGI && trxmode == DIGIMODE) {
-	fldigi_to_rx();
-    } else if (trxmode == CWMODE) {
-	if (cwkeyer == NET_KEYER) {
-
-	    if (netkeyer(K_ABORT, NULL) < 0) {
-
-		TLF_LOG_WARN("keyer not active; switching to SSB");
-		trxmode = SSBMODE;
-		clear_display();
-
-	    }
-	} else if (cwkeyer == HAMLIB_KEYER) {
-	    if (hamlib_keyer_stop() != RIG_OK) {
-		TLF_LOG_WARN("could not stop CW sending");
-	    }
-	}
-    } else {
-	return (1);
-    }
-    return (0);
+int hamlib_keyer_send(char *cwmessage) {
+    return rig_send_morse(my_rig, RIG_VFO_CURR, cwmessage);
 }
 
+int hamlib_keyer_set_speed(int cwspeed) {
+    value_t spd;
+    spd.i = cwspeed;
+
+    return rig_set_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, spd);
+}
+
+int hamlib_keyer_stop() {
+    return rig_stop_morse(my_rig, RIG_VFO_CURR);
+}

--- a/src/hamlib_keyer.h
+++ b/src/hamlib_keyer.h
@@ -1,0 +1,22 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2001-2002-2003-2004-2005 Rein Couperus <pa0r@amsat.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+int hamlib_keyer_send(char *cwmessage);
+int hamlib_keyer_set_speed(int cwspeed);
+int hamlib_keyer_stop();

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -157,7 +157,7 @@ void keyer(void) {
 	if ((x >= ' ' && x <= 'Z') || x == LINEFEED) { /* ~printable or LF */
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 		mfj1278_control(x);
-	    } else if (cwkeyer == NET_KEYER) {
+	    } else if (cwkeyer == NET_KEYER || cwkeyer == HAMLIB_KEYER) {
 		keyer_append_char(x);
 	    }
 

--- a/src/main.c
+++ b/src/main.c
@@ -817,6 +817,10 @@ static void keyer_init() {
 
     }
 
+    if (cwkeyer == HAMLIB_KEYER) {
+	showmsg("CW-Keyer is Hamlib");
+    }
+
     if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER ||
 	    digikeyer == GMFSK) {
 	init_controller();

--- a/src/main.c
+++ b/src/main.c
@@ -818,6 +818,13 @@ static void keyer_init() {
     }
 
     if (cwkeyer == HAMLIB_KEYER) {
+	if (!trx_control) {
+	    showmsg("CW-Keyer is set to HAMLIB");
+	    showmsg("BUT hamlib is not working !!");
+	    sleep(1);
+	    endwin();
+	    exit(EXIT_FAILURE);
+	}
 	showmsg("CW-Keyer is Hamlib");
     }
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1126,6 +1126,7 @@ static config_t logcfg_configs[] = {
     {"CONTINENT_LIST_POINTS",   CFG_INT(continentlist_points, 0, INT32_MAX)},
 
     {"NETKEYER",        CFG_INT_CONST(cwkeyer, NET_KEYER)},
+    {"HAMLIB_KEYER",    CFG_INT_CONST(cwkeyer, HAMLIB_KEYER)},
     {"FIFO_INTERFACE",  CFG_INT_CONST(packetinterface, FIFO_INTERFACE)},
     {"LONG_SERIAL",     CFG_INT_CONST(shortqsonr, 0)},
     {"CLUSTER",         CFG_INT_CONST(cluster, CLUSTER)},

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 
 #include "bands.h"
+#include "cw_utils.h"
 #include "sendqrg.h"
 #include "startmsg.h"
 #include "gettxinfo.h"
@@ -69,6 +70,7 @@ int init_tlf_rig(void) {
     dcd_type_t dcd_type = RIG_DCD_NONE;
 
     const struct rig_caps *caps;
+    value_t rig_cwspeed;
 
     /*
      * allocate memory, setup & open port
@@ -98,6 +100,14 @@ int init_tlf_rig(void) {
 	} else {
 	    rigptt = 0;
 	    showmsg("Controlling PTT via Hamlib is not supported for that rig!");
+	}
+    }
+
+    if (cwkeyer == HAMLIB_KEYER) {
+	/* FIXME: query actual rig (might vary when going through rigctld */
+	if (rig_get_function_ptr(myrig_model, RIG_FUNCTION_SEND_MORSE) == NULL) {
+	    cwkeyer = NO_KEYER;
+	    showmsg("Sending Morse via Hamlib is not supported for that rig!");
 	}
     }
 
@@ -135,6 +145,19 @@ int init_tlf_rig(void) {
     }
 
     shownr("Freq =", (int) rigfreq);
+
+    if (cwkeyer == HAMLIB_KEYER) {
+	retcode = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &rig_cwspeed); /* read cw speed from rig */
+
+	if (retcode == RIG_OK) {
+	    shownr("CW speed = ", (int) rig_cwspeed.i);
+	    SetCWSpeed(rig_cwspeed.i);
+	} else {
+	    showmsg("Could not read CW speed from rig");
+	    if (!debugflag)
+		return -1;
+	}
+    }
 
     if (debugflag) {	// debug rig control
 	debug_tlf_rig();

--- a/src/speedupndown.c
+++ b/src/speedupndown.c
@@ -29,6 +29,7 @@
 #include "cw_utils.h"
 #include "err_utils.h"
 #include "globalvars.h"
+#include "hamlib_keyer.h"
 #include "netkeyer.h"
 #include "sendbuf.h"
 #include "tlf.h"
@@ -39,8 +40,9 @@ void setspeed(void) {
 
     int retval = 0;
     char buff[3];
+    int cwspeed = GetCWSpeed();
 
-    snprintf(buff, 3, "%2u", GetCWSpeed());
+    snprintf(buff, 3, "%2u", cwspeed);
 
     if (cwkeyer == NET_KEYER) {
 
@@ -49,6 +51,16 @@ void setspeed(void) {
 	if (retval < 0) {
 	    TLF_LOG_WARN("keyer not active");
 //                      trxmode = SSBMODE;
+	    clear_display();
+	}
+    }
+
+    if (cwkeyer == HAMLIB_KEYER) {
+
+	retval = hamlib_keyer_set_speed(cwspeed);
+
+	if (retval < 0) {
+	    TLF_LOG_WARN("Problem with Hamlib keyer");
 	    clear_display();
 	}
     }

--- a/src/stoptx.c
+++ b/src/stoptx.c
@@ -22,6 +22,7 @@
 *--------------------------------------------------------------*/
 
 
+#include <hamlib/rig.h>
 #include "clear_display.h"
 #include "err_utils.h"
 #include "globalvars.h"
@@ -47,8 +48,9 @@ int stoptx(void) {
 
 	    }
 	} else if (cwkeyer == HAMLIB_KEYER) {
-	    if (hamlib_keyer_stop() != RIG_OK) {
-		TLF_LOG_WARN("could not stop CW sending");
+	    int error = hamlib_keyer_stop();
+	    if (error != RIG_OK) {
+		TLF_LOG_WARN("CW stop error: %s", rigerror(error));
 	    }
 	}
     } else {

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -32,6 +32,7 @@ enum {
     MFJ1278_KEYER,
     GMFSK,
     FLDIGI,
+    HAMLIB_KEYER,
 };
 
 #define SINGLE 0        /* single op */

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -29,6 +29,7 @@
 #include "err_utils.h"
 #include "ignore_unused.h"
 #include "globalvars.h"
+#include "hamlib_keyer.h"
 #include "netkeyer.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -93,6 +94,8 @@ void write_keyer(void) {
 	fldigi_send_text(tosend);
     } else if (cwkeyer == NET_KEYER) {
 	netkeyer(K_MESSAGE, tosend);
+    } else if (cwkeyer == HAMLIB_KEYER) {
+	hamlib_keyer_send(tosend);
 
     } else if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 	if ((bfp = fopen(controllerport, "a")) == NULL) {


### PR DESCRIPTION
- Fatal error if HAMLIB_KEYER set but hamlib not working on start
- Decode and show hamlib errors on send/stop failures
- Ignore +/- speed up/slow down instructions as they don't work with hamlib

----

I've taken the best bits of my patch and rebased them on yours :-)