### PR TITLE
Hamlib cw

### DIFF
--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -503,7 +503,7 @@ static void checkexchange_cqww(char *comment, bool interactive) {
 	// get zone nr, use fix if available
 	index = g_match_info_fetch(match_info, 1);
 	gchar *index_fix = g_match_info_fetch(match_info, 3);
-	if (index_fix != NULL) {
+	if (index_fix != NULL && strlen(index_fix) >= 1 && strlen(index_fix) <= 4) {
 	    g_free(index);
 	    index = index_fix;
 	}

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -33,6 +33,7 @@
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "globalvars.h"
+#include "hamlib_keyer.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "callinput.h"
@@ -191,12 +192,12 @@ void gettxinfo(void) {
 
 	/* read speed from rig */
 	if (cwkeyer == HAMLIB_KEYER) {
-	    value_t rig_cwspeed;
-	    retval = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &rig_cwspeed); /* initialize RIG_VFO_CURR */
+	    int rig_cwspeed;
+	    retval = hamlib_keyer_get_speed(&rig_cwspeed);
 
 	    if (retval == RIG_OK) {
-		if (GetCWSpeed() != rig_cwspeed.i) { // FIXME: doesn't work if rig speed is between the values from CW_SPEEDS
-		    SetCWSpeed(rig_cwspeed.i);
+		if (GetCWSpeed() != rig_cwspeed) { // FIXME: doesn't work if rig speed is between the values from CW_SPEEDS
+		    SetCWSpeed(rig_cwspeed);
 
 		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 		    mvprintw(0, 14, "%2u", GetCWSpeed());

--- a/src/hamlib_keyer.c
+++ b/src/hamlib_keyer.c
@@ -22,6 +22,14 @@
 #include "globalvars.h"
 #include "hamlib_keyer.h"
 
+bool rig_has_send_morse() {
+   return (my_rig->caps->send_morse != NULL);
+}
+
+bool rig_has_stop_morse() {
+    return (my_rig->caps->stop_morse != NULL);
+}
+
 int hamlib_keyer_send(char *cwmessage) {
     return rig_send_morse(my_rig, RIG_VFO_CURR, cwmessage);
 }
@@ -34,5 +42,9 @@ int hamlib_keyer_set_speed(int cwspeed) {
 }
 
 int hamlib_keyer_stop() {
-    return rig_stop_morse(my_rig, RIG_VFO_CURR);
+    if (rig_has_stop_morse()) {
+	return rig_stop_morse(my_rig, RIG_VFO_CURR);
+    } else {
+	return RIG_OK;
+    }
 }

--- a/src/hamlib_keyer.c
+++ b/src/hamlib_keyer.c
@@ -17,6 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
+#include <assert.h>
 #include <hamlib/rig.h>
 
 #include "globalvars.h"
@@ -30,15 +31,25 @@ bool rig_has_stop_morse() {
     return (my_rig->caps->stop_morse != NULL);
 }
 
-int hamlib_keyer_send(char *cwmessage) {
-    return rig_send_morse(my_rig, RIG_VFO_CURR, cwmessage);
-}
-
 int hamlib_keyer_set_speed(int cwspeed) {
     value_t spd;
     spd.i = cwspeed;
 
     return rig_set_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, spd);
+}
+
+int hamlib_keyer_get_speed( int *cwspeed) {
+    value_t value;
+
+    assert (cwspeed != NULL);
+    int ret = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &value);
+    if (ret == RIG_OK)
+	*cwspeed = value.i;
+    return ret;
+}
+
+int hamlib_keyer_send(char *cwmessage) {
+    return rig_send_morse(my_rig, RIG_VFO_CURR, cwmessage);
 }
 
 int hamlib_keyer_stop() {

--- a/src/hamlib_keyer.h
+++ b/src/hamlib_keyer.h
@@ -19,6 +19,7 @@
 
 bool rig_has_send_morse();
 bool rig_has_stop_morse();
-int hamlib_keyer_send(char *cwmessage);
 int hamlib_keyer_set_speed(int cwspeed);
+int hamlib_keyer_get_speed( int *cwspeed);
+int hamlib_keyer_send(char *cwmessage);
 int hamlib_keyer_stop();

--- a/src/hamlib_keyer.h
+++ b/src/hamlib_keyer.h
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
+bool rig_has_send_morse();
+bool rig_has_stop_morse();
 int hamlib_keyer_send(char *cwmessage);
 int hamlib_keyer_set_speed(int cwspeed);
 int hamlib_keyer_stop();

--- a/src/listmessages.c
+++ b/src/listmessages.c
@@ -41,11 +41,15 @@ char  printbuffer[160];
 
 char *formatMessage(int i) {
 
-    /* copy the message string WITHOUT trailing newline/space */
+    /* copy the message string */
     if (trxmode == DIGIMODE)
-	g_strlcpy(printbuffer,  digi_message[i],  strlen(digi_message[i]));
+	g_strlcpy(printbuffer,  digi_message[i],  sizeof(printbuffer));
     else
-	g_strlcpy(printbuffer,  message[i],  strlen(message[i]));
+	g_strlcpy(printbuffer,  message[i],  sizeof(printbuffer));
+
+    /* and strip off trailing newline/whitespace */
+    g_strchomp(printbuffer);
+
     /* and fill up with spaces */
     strcat(printbuffer, backgrnd_str);
     printbuffer[LIST_WIDTH - 7] = '\0';

--- a/src/main.c
+++ b/src/main.c
@@ -221,9 +221,9 @@ char message[25][80] = /**< Array of CW messages
 			* message[1]  (F2)  - insert pressed
  			*/
 {
-    "TEST %\n", "@ DE %\n", "@ [\n", "TU 73\n", " @\n", "%\n",
-    "@ SRI QSO B4 GL\n", "AGN\n",
-    " ?\n", " QRZ?\n", " PSE K\n", "TEST % %\n", "@ [\n", "TU %\n",
+    "TEST %", "@ DE %", "@ [", "TU 73", "@", "%",
+    "@ SRI QSO B4 GL", "AGN",
+    "?", "QRZ?", "PSE K", "TEST % %", "@ [", "TU %",
     "", "", "", "", "", "", "", "", "", "", ""
 };
 
@@ -232,12 +232,24 @@ char *digi_message[sizeof(message) / sizeof(message[0])];
 char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   * See description of message[]
 			   */
-{ "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
+    { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
-char qtc_recv_msgs[12][80] = {"QTC?\n", "QRV\n", "R\n", "", "TIME?\n", "CALL?\n", "NR?\n", "AGN\n", "", "QSL ALL\n", "", ""}; // QTC receive windowS Fx messages
-char qtc_send_msgs[12][80] = {"QRV?\n", "QTC sr/nr\n", "", "", "TIME\n", "CALL\n", "NR\n", "", "", "", "", ""}; // QTC send window Fx messages
-char qtc_phrecv_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when receives QTCs
-char qtc_phsend_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when send QTCs
+char qtc_recv_msgs[12][80] = {
+    "QTC?", "QRV", "R", "", "TIME?", "CALL?",
+    "NR?", "AGN", "", "QSL ALL", "", ""};	// QTC receive windows Fx messages
+
+char qtc_send_msgs[12][80] = {
+    "QRV?", "QTC sr/nr", "", "", "TIME", "CALL",
+    "NR", "", "", "", "", ""};		    	// QTC send window Fx messages
+
+char qtc_phrecv_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when receives QTCs
+
+char qtc_phsend_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when send QTCs
+
 bool qtcrec_record = false;
 char qtcrec_record_command[2][50] = {"rec -q 8000", "-q &"};
 char qtcrec_record_command_shutdown[50] = "pkill -SIGINT -n rec";

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@
 #include "getmessages.h"
 #include "getwwv.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "hamlib_keyer.h"
 #include "initial_exchange.h"
 #include "lancode.h"
 #include "logit.h"
@@ -828,14 +829,27 @@ static void keyer_init() {
     }
 
     if (cwkeyer == HAMLIB_KEYER) {
+	showmsg("CW-Keyer is Hamlib");
 	if (!trx_control) {
-	    showmsg("CW-Keyer is set to HAMLIB");
-	    showmsg("BUT hamlib is not working !!");
+	    showmsg("Radio control is not activated!!");
 	    sleep(1);
 	    endwin();
 	    exit(EXIT_FAILURE);
 	}
-	showmsg("CW-Keyer is Hamlib");
+	if (!rig_has_send_morse()) {
+	    showmsg("Rig does not support CW via Hamlib");
+	    sleep(1);
+	    endwin();
+	    exit(EXIT_FAILURE);
+	}
+	if (!rig_has_stop_morse()) {
+	    showmsg("Rig does not support stopping CW!!");
+	    showmsg("Continue anyway Y/(N)?");
+	    if (toupper(key_get()) != 'Y') {
+		endwin();
+		exit(1);
+	    }
+	}
     }
 
     if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER ||
@@ -971,8 +985,6 @@ int main(int argc, char *argv[]) {
     showmsg("");
 
     memset(&my, 0, sizeof(my));
-
-    rig_set_debug(RIG_DEBUG_NONE);
 
     total = 0;
     if (databases_load() == EXIT_FAILURE) {

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -43,6 +43,9 @@ static void enter_message(int bufnr) {
 	msg = message[bufnr];
 
     g_strlcpy(printbuf, msg, sizeof(printbuf));
+
+    g_strchomp(printbuf);
+
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
     mvaddstr(15, 4, printbuf);
     refreshp();

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1084,9 +1084,9 @@ static config_t logcfg_configs[] = {
     {"ALT_([0-9])",     CFG_MESSAGE(message, CQ_TU_MSG + 1)},
     {"S&P_CALL_MSG",    CFG_MESSAGE(message, SP_CALL_MSG)},
 
-    {"VKM([1-9]|1[0-2])",   CFG_MESSAGE_CHOMP(ph_message, -1)},
-    {"VKCQM",               CFG_MESSAGE_CHOMP(ph_message, CQ_TU_MSG)},
-    {"VKSPM",               CFG_MESSAGE_CHOMP(ph_message, SP_TU_MSG)},
+    {"VKM([1-9]|1[0-2])",   CFG_MESSAGE(ph_message, -1)},
+    {"VKCQM",               CFG_MESSAGE(ph_message, CQ_TU_MSG)},
+    {"VKSPM",               CFG_MESSAGE(ph_message, SP_TU_MSG)},
 
     {"DKF([1-9]|1[0-2])",   CFG_MESSAGE_DYNAMIC(digi_message, -1)},
     {"DKCQM",               CFG_MESSAGE_DYNAMIC(digi_message, CQ_TU_MSG)},
@@ -1095,14 +1095,14 @@ static config_t logcfg_configs[] = {
     {"ALT_DK([1-9]|10)",    CFG_MESSAGE_DYNAMIC(digi_message, CQ_TU_MSG)},
 
     {"QR_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_recv_msgs, -1) },
-    {"QR_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phrecv_message, -1) },
-    {"QR_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, CQ_TU_MSG) },
-    {"QR_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, SP_TU_MSG) },
+    {"QR_VKM([1-9]|1[0-2])",    CFG_MESSAGE(qtc_phrecv_message, -1) },
+    {"QR_VKCQM",                CFG_MESSAGE(qtc_phrecv_message, CQ_TU_MSG) },
+    {"QR_VKSPM",                CFG_MESSAGE(qtc_phrecv_message, SP_TU_MSG) },
 
     {"QS_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_send_msgs, -1) },
-    {"QS_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phsend_message, -1) },
-    {"QS_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, CQ_TU_MSG) },
-    {"QS_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, SP_TU_MSG) },
+    {"QS_VKM([1-9]|1[0-2])",    CFG_MESSAGE(qtc_phsend_message, -1) },
+    {"QS_VKCQM",                CFG_MESSAGE(qtc_phsend_message, CQ_TU_MSG) },
+    {"QS_VKSPM",                CFG_MESSAGE(qtc_phsend_message, SP_TU_MSG) },
 
     {"TLFCOLOR([1-6])",  NEED_PARAM, cfg_tlfcolor},
 
@@ -1253,6 +1253,10 @@ static int apply_config(const char *keyword, const char *param,
 
 	case PARSE_INTEGER_OUT_OF_RANGE:
 	    WrongFormat_details(keyword, "value out of range");
+	    break;
+
+	case PARSE_STRING_TOO_LONG:
+	    WrongFormat_details(keyword, "value too long");
 	    break;
 
 	default:

--- a/src/parse_logcfg.h
+++ b/src/parse_logcfg.h
@@ -109,11 +109,7 @@ typedef struct {
         (cfg_arg_t){.char_pp=&var, .chomp=true, \
                     .string_type=DYNAMIC}
 
-#define CFG_MESSAGE(var, i)     NEED_PARAM, cfg_string, \
-        (cfg_arg_t){.msg=var, .base=i, .size=80, \
-                    .string_type=MESSAGE}
-
-#define CFG_MESSAGE_CHOMP(var, i)   NEED_PARAM, cfg_string, \
+#define CFG_MESSAGE(var, i)   NEED_PARAM, cfg_string, \
         (cfg_arg_t){.msg=var, .base=i, .size=80, .chomp=true, \
                     .string_type=MESSAGE}
 

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -729,9 +729,6 @@ void qtc_main_panel(int direction) {
 		if (trxmode == DIGIMODE) {
 		    if (direction == SEND && (activefield == 0 || activefield == 2)
 			    && qtclist.totalsent == 0) {
-			if (qtc_send_msgs[1][strlen(qtc_send_msgs[1]) - 1] == 10) {
-			    qtc_send_msgs[1][strlen(qtc_send_msgs[1]) - 1] = '\0';
-			}
 			tlen = strlen(qtc_send_msgs[1]) - 5; // len("sr/nr") = 5
 			char tmess[300], timec[40];
 			int ql;
@@ -854,10 +851,6 @@ void qtc_main_panel(int direction) {
 		    }
 
 		    if (direction == SEND && strlen(qtc_send_msgs[x - KEY_F(1)]) > 0) {
-			if (qtc_send_msgs[x - KEY_F(1)][strlen(qtc_send_msgs[x - KEY_F(
-				1)]) - 1] == '\n') {
-			    qtc_send_msgs[x - KEY_F(1)][strlen(qtc_send_msgs[x - KEY_F(1)]) - 1] = 0;
-			}
 			tlen = strlen(qtc_send_msgs[x - KEY_F(1)]) - 5; // len("sr/nr") = 5
 			char tmess[60];
 			tmess[0] = '\0';

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -225,8 +225,11 @@ void ExpandMacro(void) {
 
 
     replace_all(buffer, BUFSIZE, "!", comment);
+
     if (trxmode == DIGIMODE)
-	replace_all(buffer, BUFSIZE, "|", "\r");   /* CR */
+	replace_all(buffer, BUFSIZE, "|", "\r");    /* CR */
+    else
+	replace_all(buffer, BUFSIZE, "|", "");	    /* drop it */
 }
 
 

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -74,6 +74,8 @@ int init_tlf_rig(void) {
     const struct rig_caps *caps;
     value_t rig_cwspeed;
 
+    rig_set_debug(RIG_DEBUG_NONE);
+
     /*
      * allocate memory, setup & open port
      */
@@ -139,15 +141,6 @@ int init_tlf_rig(void) {
     }
 
     shownr("Freq =", (int) rigfreq);
-
-    // check if rig supports sending CW
-    if (cwkeyer == HAMLIB_KEYER) {
-	int retcode = hamlib_keyer_send("");
-	if (retcode != RIG_OK) {
-	    cwkeyer = NO_KEYER;
-	    showmsg("Sending Morse via Hamlib is not supported for that rig!");
-	}
-    }
 
     if (cwkeyer == HAMLIB_KEYER) {
 	retcode = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &rig_cwspeed); /* read cw speed from rig */

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -72,7 +72,7 @@ int init_tlf_rig(void) {
     dcd_type_t dcd_type = RIG_DCD_NONE;
 
     const struct rig_caps *caps;
-    value_t rig_cwspeed;
+    int rig_cwspeed;
 
     rig_set_debug(RIG_DEBUG_NONE);
 
@@ -143,11 +143,11 @@ int init_tlf_rig(void) {
     shownr("Freq =", (int) rigfreq);
 
     if (cwkeyer == HAMLIB_KEYER) {
-	retcode = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &rig_cwspeed); /* read cw speed from rig */
+	retcode = hamlib_keyer_get_speed(&rig_cwspeed); /* read cw speed from rig */
 
 	if (retcode == RIG_OK) {
-	    shownr("CW speed = ", (int) rig_cwspeed.i);
-	    SetCWSpeed(rig_cwspeed.i);
+	    shownr("CW speed = ", rig_cwspeed);
+	    SetCWSpeed(rig_cwspeed);
 	} else {
 	    TLF_LOG_WARN("Could not read CW speed from rig: %s", rigerror(retcode));
 	    if (!debugflag)

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -25,6 +25,7 @@
 #include "bands.h"
 #include "cw_utils.h"
 #include "err_utils.h"
+#include "hamlib_keyer.h"
 #include "sendqrg.h"
 #include "startmsg.h"
 #include "gettxinfo.h"

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -95,8 +95,8 @@ int lookup_key(char *capability) {
 
 /** lookup all needed special keys not defined by ncurses */
 void lookup_keys() {
-    bool alt_not_ok = 0;
-    bool ctrl_not_ok = 0;
+    bool alt_not_ok = false;
+    bool ctrl_not_ok = false;
 
     key_kNXT3 = lookup_key("kNXT3");
     key_kPRV3 = lookup_key("kPRV3");
@@ -105,15 +105,15 @@ void lookup_keys() {
 
     if ((key_kNXT3 || key_kPRV3) == 0) {
 	showmsg("Terminal does not support Alt-PgUp/PgDn keys");
-	alt_not_ok = 1;
+	alt_not_ok = true;
     }
 
     if ((key_kNXT5 || key_kPRV5) == 0) {
 	showmsg("Terminal does not support Ctrl-PgUp/PgDn keys");
-	ctrl_not_ok = 1;
+	ctrl_not_ok = true;
     }
 
-    if (alt_not_ok == 1 && ctrl_not_ok == 1) {
+    if (alt_not_ok && ctrl_not_ok) {
 	showmsg("See ':CQD' in man page for setting Auto_CQ delay");
 	showmsg("");
 	beep();

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -95,7 +95,8 @@ int lookup_key(char *capability) {
 
 /** lookup all needed special keys not defined by ncurses */
 void lookup_keys() {
-    int not_ok = 0;
+    bool alt_not_ok = 0;
+    bool ctrl_not_ok = 0;
 
     key_kNXT3 = lookup_key("kNXT3");
     key_kPRV3 = lookup_key("kPRV3");
@@ -104,15 +105,15 @@ void lookup_keys() {
 
     if ((key_kNXT3 || key_kPRV3) == 0) {
 	showmsg("Terminal does not support Alt-PgUp/PgDn keys");
-	not_ok = 1;
+	alt_not_ok = 1;
     }
 
     if ((key_kNXT5 || key_kPRV5) == 0) {
 	showmsg("Terminal does not support Ctrl-PgUp/PgDn keys");
-	not_ok = 1;
+	ctrl_not_ok = 1;
     }
 
-    if (not_ok == 1) {
+    if (alt_not_ok == 1 && ctrl_not_ok == 1) {
 	showmsg("See ':CQD' in man page for setting Auto_CQ delay");
 	showmsg("");
 	beep();

--- a/test/data.c
+++ b/test/data.c
@@ -186,9 +186,9 @@ char message[25][80] = /**< Array of CW/DigiMode messages
 			* message[1]  (F2)  - insert pressed
  			*/
 {
-    "TEST %\n", "@ DE %\n", "@ [\n", "TU 73\n", " @\n", "%\n",
-    "@ SRI QSO B4 GL\n", "AGN\n",
-    " ?\n", " QRZ?\n", " PSE K\n", "TEST % %\n", "@ [\n", "TU %\n",
+    "TEST %", "@ DE %", "@ [", "TU 73", "@", "%",
+    "@ SRI QSO B4 GL", "AGN",
+    "?", "QRZ?", "PSE K", "TEST % %", "@ [", "TU %",
     "", "", "", "", "", "", "", "", "", "", ""
 };
 
@@ -200,12 +200,24 @@ char *digi_message[sizeof(message) / sizeof(message[0])];
 char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   * See description of message[]
 			   */
-{ "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
+    { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
-char qtc_recv_msgs[12][80] = {"QTC?\n", "QRV\n", "R\n", "", "TIME?\n", "CALL?\n", "NR?\n", "AGN\n", "", "QSL ALL\n", "", ""}; // QTC receive windowS Fx messages
-char qtc_send_msgs[12][80] = {"QRV?\n", "QTC sr/nr\n", "", "", "TIME\n", "CALL\n", "NR\n", "", "", "", "", ""}; // QTC send window Fx messages
-char qtc_phrecv_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when receives QTCs
-char qtc_phsend_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when send QTCs
+char qtc_recv_msgs[12][80] = {
+    "QTC?", "QRV", "R", "", "TIME?", "CALL?",
+    "NR?", "AGN", "", "QSL ALL", "", ""}; // QTC receive windows Fx messages
+
+char qtc_send_msgs[12][80] = {
+    "QRV?", "QTC sr/nr", "", "", "TIME", "CALL",
+    "NR", "", "", "", "", ""};		    	// QTC send window Fx messages
+
+char qtc_phrecv_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when receives QTCs
+
+char qtc_phsend_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when send QTCs
+
 bool qtcrec_record = false;
 char qtcrec_record_command[2][50] = {"rec -q 8000", "-q &"};
 char qtcrec_record_command_shutdown[50] = "pkill -SIGINT -n rec";

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -278,6 +278,13 @@ void test_keyer_device(void **state) {
     assert_string_equal(keyer_device, "/dev/tty0");
 }
 
+void test_keyer_device_too_long(void **state) {
+    int rc = call_parse_logcfg("KEYER_DEVICE=/dev/bus/usb/002/001");
+    assert_int_equal(rc, PARSE_ERROR);
+    assert_string_equal(showmsg_spy,
+			"Wrong parameter for keyword 'KEYER_DEVICE': value too long.\n");
+}
+
 void test_editor(void **state) {
     int rc = call_parse_logcfg("EDITOR= pico \n");   // space around argument
     assert_int_equal(rc, 0);
@@ -411,7 +418,7 @@ void test_fn(void **state) {
 	sprintf(line, "F%d= %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "MSG%d ABC \n", i);   // trailing space+NL are kept, FIXME
+	sprintf(msg, "MSG%d ABC", i);
 	assert_string_equal(message[j], msg);
     }
 }
@@ -425,7 +432,7 @@ void test_alt_n(void **state) {
 	sprintf(line, "ALT_%d= %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "MSG%d ALT \n", i);   // trailing space+NL are kept, FIXME
+	sprintf(msg, "MSG%d ALT", i);
 	assert_string_equal(message[j], msg);
     }
 }
@@ -433,19 +440,19 @@ void test_alt_n(void **state) {
 void test_sp_tu_msg(void **state) {
     int rc = call_parse_logcfg("S&P_TU_MSG=TU\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(message[SP_TU_MSG], "TU\n");
+    assert_string_equal(message[SP_TU_MSG], "TU");
 }
 
 void test_cq_tu_msg(void **state) {
     int rc = call_parse_logcfg("CQ_TU_MSG=TU QRZ?\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(message[CQ_TU_MSG], "TU QRZ?\n");
+    assert_string_equal(message[CQ_TU_MSG], "TU QRZ?");
 }
 
 void test_sp_call_msg(void **state) {
     int rc = call_parse_logcfg("S&P_CALL_MSG=DE AB1CD\r\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(message[SP_CALL_MSG], "DE AB1CD\r\n");  // FIXME line end...
+    assert_string_equal(message[SP_CALL_MSG], "DE AB1CD");
 }
 
 typedef struct {
@@ -577,7 +584,7 @@ void test_qr_fn(void **state) {
 	sprintf(line, "QR_F%d = %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "QRMSG%d MNO \n", i);    // FIXME NL is kept
+	sprintf(msg, "QRMSG%d MNO", i);
 	assert_string_equal(qtc_recv_msgs[j], msg);
     }
 }
@@ -592,7 +599,7 @@ void test_qs_fn(void **state) {
 	sprintf(line, "QS_F%d = %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "QSMSG%d MNO \n", i);    // FIXME NL is kept
+	sprintf(msg, "QSMSG%d MNO", i);
 	assert_string_equal(qtc_send_msgs[j], msg);
     }
 }

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2420,9 +2420,10 @@ pass another value (in seconds) after the \(oq=\(cq sign.
 .IP
 There must be an integral number of time sections per hour!
 .
-.SS CW and Voice Keyer Macros
+.SS CW, Digimode and Voice Keyer Macros
 .
-The following parameters configure the CW and voice mode keyer message macros.
+The following parameters configure the CW, Digimode and voice mode keyer
+message macros.
 .
 .TP
 .B Macro characters in the message strings
@@ -2450,11 +2451,17 @@ The following parameters configure the CW and voice mode keyer message macros.
 = SN,
 .B &
 = AS,
-.B > =
-BK,
+.B > 
+= BK,
 .B !
 = his serial (e.g. confirm exchange of station in
-.BR DIG imode).
+.BR DIG imode),
+.B |
+= carriage return (only in digi mode messages).
+.
+.P
+Be aware that unspecified digimode messages gets the value of their CW
+counterpart prepended with '|'.
 .
 .TP
 \fBF1\fR=\fI"cw message 1"\fR


### PR DESCRIPTION
Some cleanup and a fix for the stop_morse problem.

Please pickup the PR. We can then merge your PR into master.

Only problem here are inserted spaces after each character when using the interactive keyer. Seems hamlib or my rig inserts a word spacing between each rig_sent_morse() commands. Can you please check how it is on your side?

